### PR TITLE
add std::filesystem to tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,8 +73,10 @@ matrix:
 
     - name: "mac"
       os: osx
-      osx_image: xcode11.2
+      osx_image: xcode11.3
       compiler: clang
+      #env:
+      #  - cmake_extra_flags="-DMACOSX_DEPLOYMENT_TARGET=10.15"
 
     - name: "coverity scan"
       if: branch = coverity_scan
@@ -160,6 +162,6 @@ script:
       -DLIBEXT_EXAMPLES="$examples" \
       -DLIBEXT_TESTS_NO_TIME_CRITICAL=ON \
       $cmake_extra_flags
-  - ../build-support/lib/bash_build_scripts/build
-  - if [[ $coverage == "false" ]]; then ../build-support/lib/bash_build_scripts/test $tests; fi
-  - if [[ $coverage == "true" ]]; then ../build-support/scripts/coverage; fi
+  - ../build-support/lib/bash_build_scripts/build || exit 1
+  - if [[ $coverage == "false" ]]; then ../build-support/lib/bash_build_scripts/test $tests || exit 1 ; fi
+  - if [[ $coverage == "true" ]]; then ../build-support/scripts/coverage || exit 1 ; fi

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,11 @@ list(APPEND test-files
 )
 endif()
 
+if(NOT APPLE)
+    # wait for MacOS 10.15 to arrive in travis
+    find_package(Filesystem REQUIRED Final Experimental)
+endif()
+
 foreach(suffix IN ITEMS "")
     #build one executable
     set(test_sources)
@@ -45,7 +50,12 @@ foreach(suffix IN ITEMS "")
     set(test_target "test-ext-basics${suffix}")
     add_executable("${test_target}" gtest.cpp ${test_sources})
     target_include_directories("${test_target}" SYSTEM PRIVATE ${gtest_SOURCE_DIR}/include)
-    target_link_libraries("${test_target}" ext::basics${suffix} gtest_main gtest Threads::Threads)
+    target_link_libraries("${test_target}"
+        ext::basics${suffix}
+        gtest_main gtest
+        Threads::Threads
+        #std::filesystem # needs to work on travis
+    )
     target_compile_options("${test_target}" PRIVATE ${ext_stone-warnings})
     target_compile_definitions("${test_target}" PUBLIC EXT_CHECKED=1 EXT_IN_TEST=1)
     # -- repeated calls should append which does not happen for me (cmake 3.16 on linux)


### PR DESCRIPTION
# filesystem
- [x] linux - gcc
- [x] linux - clang
- [x] windows
- [ ] mac

# problems
Maybe MacOS 10.15 is required.
- https://stackoverflow.com/questions/54786973/what-library-to-link-to-for-stdfilesystem-with-xcode/54834871#54834871